### PR TITLE
Fix: Install tidyverse package in GitHub Actions workflow

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -36,7 +36,8 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev pandoc
 
           # Install R packages
-          Rscript -e "install.packages(c('tidyverse', 'ggthemes', 'scales', 'shiny', 'httr', 'jsonlite', 'fredr', 'wbdata', 'soccerdata', 'googledrive', 'googlesheets4', 'ragg', 'rvest'), dependencies = TRUE)"
+          Rscript -e "install.packages(c('tidyverse', 'ggthemes', 'scales', 'shiny', 'httr', 'jsonlite', 'fredr', 'wbdata', 'soccerdata', 'googledrive', 'googlesheets4', 'ragg', 'rvest', 'remotes'), dependencies = TRUE)"
+          Rscript -e "remotes::install_cran('tidyverse')"
         # Note: 'dependencies = TRUE' ensures that all recursive dependencies are also installed.
 
       - name: Install Python


### PR DESCRIPTION
The GitHub Actions workflow was failing because the tidyverse R package was not found. This commit modifies the workflow to explicitly install tidyverse using `remotes::install_cran('tidyverse')` before rendering the Quarto project. This ensures the package is available and resolves the error.